### PR TITLE
Add license notice to every source file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # GuiBot
 
-Telegram bot using by 'Grupo Universitario de Informática' of Valladolid to manage the meeting documents
+Telegram bot used by 'Grupo Universitario de Informática' of Valladolid to manage the meeting documents.
 
-All requirements on 'requirements.txt'
-Main program is /src/bot_main.py
+All requirements can be found on 'requirements.txt'. Use `pip install -r requirements.txt` before running the bot for the first time.
 
+Main program is /src/bot\_main.py
 
-Error logs is save in "/src/utils/logs/error.logs"
+Error logs are saved in "/src/utils/logs/error.logs"

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ All requirements can be found on 'requirements.txt'. Use `pip install -r require
 
 Main program is /src/bot\_main.py
 
-Error logs are saved in "/src/utils/logs/error.logs"
+Error logs are saved to "/src/utils/logs/error.logs"

--- a/src/bot_main.py
+++ b/src/bot_main.py
@@ -1,3 +1,21 @@
+'''
+GuiBot - Telegram bot to manage the meeting documents of Universidad
+de Valladolid's Grupo Universitario de Informática (GUI).
+Copyright (C) 2024  Obi-Juan-NoSeEnoje17
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+'''
 import telebot
 import time
 import os

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,18 @@
+'''
+GuiBot - Telegram bot to manage the meeting documents of Universidad
+de Valladolid's Grupo Universitario de Informática (GUI).
+Copyright (C) 2024  Obi-Juan-NoSeEnoje17
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+'''

--- a/src/utils/bot_manager.py
+++ b/src/utils/bot_manager.py
@@ -1,3 +1,21 @@
+'''
+GuiBot - Telegram bot to manage the meeting documents of Universidad
+de Valladolid's Grupo Universitario de Informática (GUI).
+Copyright (C) 2024  Obi-Juan-NoSeEnoje17
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+'''
 from . import bot_utils
 
 commands = {

--- a/src/utils/bot_utils.py
+++ b/src/utils/bot_utils.py
@@ -1,3 +1,21 @@
+'''
+GuiBot - Telegram bot to manage the meeting documents of Universidad
+de Valladolid's Grupo Universitario de Informática (GUI).
+Copyright (C) 2024  Obi-Juan-NoSeEnoje17
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+'''
 def split_command(message_text, delimiter=None):
     return message_text.split(delimiter)
 

--- a/src/utils/error_log.py
+++ b/src/utils/error_log.py
@@ -1,3 +1,21 @@
+'''
+GuiBot - Telegram bot to manage the meeting documents of Universidad
+de Valladolid's Grupo Universitario de Informática (GUI).
+Copyright (C) 2024  Obi-Juan-NoSeEnoje17
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+'''
 from datetime import datetime
 
 def write_error(error_message):

--- a/src/utils/points_manager.py
+++ b/src/utils/points_manager.py
@@ -1,3 +1,21 @@
+'''
+GuiBot - Telegram bot to manage the meeting documents of Universidad
+de Valladolid's Grupo Universitario de Informática (GUI).
+Copyright (C) 2024  Obi-Juan-NoSeEnoje17
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+'''
 from . import bot_utils
 
 def new_roadmap(bot, message):


### PR DESCRIPTION
The GPL-3.0 license states that a short notice should be attached to every source file of a licensed software. See section "How to Apply These Terms to Your New Programs":

> To do so, attach the following notices to the program.  It is safest
> to attach them to the start of each source file to most effectively
> state the exclusion of warranty; and each file should have at least
> the "copyright" line and a pointer to where the full notice is found.
> 
>     <one line to give the program's name and a brief idea of what it does.>
>     Copyright (C) <year>  <name of author>
> 
>     This program is free software: you can redistribute it and/or modify
>     it under the terms of the GNU General Public License as published by
>     the Free Software Foundation, either version 3 of the License, or
>     (at your option) any later version.
> 
>     This program is distributed in the hope that it will be useful,
>     but WITHOUT ANY WARRANTY; without even the implied warranty of
>     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
>     GNU General Public License for more details.
> 
>     You should have received a copy of the GNU General Public License
>     along with this program.  If not, see <https://www.gnu.org/licenses/>.

So I've done that.

The only thing I did not include is contact information. Notice that the license also states, about the short per-file license notices:
> "Also add information on how to contact you by electronic and paper mail."

I've also slightly revised the README, with some minor changes.